### PR TITLE
Add npm `overrides` to pin patched transitive dependencies

### DIFF
--- a/Unit Testing Mocha Chai/package.json
+++ b/Unit Testing Mocha Chai/package.json
@@ -16,5 +16,10 @@
   "dependencies": {
     "chai": "^4.1.2",
     "mocha": "^10.8.2"
+  },
+  "overrides": {
+    "diff": "^5.2.2",
+    "js-yaml": "^4.1.1",
+    "minimatch": "^5.1.7"
   }
 }


### PR DESCRIPTION
### Motivation
- Address a security alert digest by forcing patched versions of vulnerable transitive packages during dependency resolution using npm `overrides`.
- Avoid changing direct dependencies (`chai`, `mocha`) while ensuring transitive packages are resolved to non-vulnerable ranges.

### Description
- Added an `overrides` block to `Unit Testing Mocha Chai/package.json` that pins `diff` to `^5.2.2`, `js-yaml` to `^4.1.1`, and `minimatch` to `^5.1.7`.
- No changes were made to direct dependencies or source code; the change is limited to dependency resolution policy in `package.json`.

### Testing
- Ran `npm test` in `Unit Testing Mocha Chai` and all tests passed (`5 passing`).
- `npm install --package-lock-only` failed due to registry access returning HTTP 403, so the lockfile could not be regenerated in this environment.
- `npm audit --json` also failed with HTTP 403 due to registry access restrictions, so remote audit details could not be retrieved here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1763a88c832ea742076d1f89a14c)